### PR TITLE
Feature input user info dennoko

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -2,7 +2,7 @@
 <project version="4">
   <component name="deploymentTargetDropDown">
     <value>
-      <entry key="PreviewBookDisplayDetails">
+      <entry key="PreviewInputUserInfoScreen">
         <State />
       </entry>
       <entry key="app">
@@ -13,12 +13,12 @@
               <deviceKey>
                 <Key>
                   <type value="VIRTUAL_DEVICE_PATH" />
-                  <value value="C:\Users\HibikiNishimura\.android\avd\Pixel_7_Pro_API_33.avd" />
+                  <value value="C:\Users\dennn\.android\avd\Pixel_7_Pro_API_33.avd" />
                 </Key>
               </deviceKey>
             </Target>
           </targetSelectedWithDropDown>
-          <timeTargetWasSelectedWithDropDown value="2023-12-31T04:41:10.726351600Z" />
+          <timeTargetWasSelectedWithDropDown value="2024-01-03T04:42:38.113504900Z" />
         </State>
       </entry>
     </value>

--- a/app/src/main/java/com/example/booksharing/MainActivity.kt
+++ b/app/src/main/java/com/example/booksharing/MainActivity.kt
@@ -51,7 +51,7 @@ class MainActivity : ComponentActivity() {
                     ) {
                         NavHost(navController = navController, startDestination = "home" , modifier = Modifier.padding(it)) {
                             composable("home") {
-                                HomeScreen()
+                                HomeScreen(navController = navController)
                             }
                         }
                     }

--- a/app/src/main/java/com/example/booksharing/ViewModel/HomeViewModel.kt
+++ b/app/src/main/java/com/example/booksharing/ViewModel/HomeViewModel.kt
@@ -41,4 +41,13 @@ class HomeViewModel: ViewModel() {
         val booksData = viewModelScope.async { manageData.getBooksByTag(db, tag) }.await()
         return booksData
     }
+
+    // 登録済みのユーザーのリストを取得する関数(初回起動時に使用)
+    var _usersList = MutableStateFlow<ImmutableList<String>?>(null)
+    val usersList = _usersList.asStateFlow()
+    fun getUsersList() {
+        viewModelScope.launch {
+            _usersList.value = manageData.getOwnerList(db)
+        }
+    }
 }

--- a/app/src/main/java/com/example/booksharing/firestore/managedata.kt
+++ b/app/src/main/java/com/example/booksharing/firestore/managedata.kt
@@ -140,6 +140,26 @@ class ManageData {
         return ImmutableList.copyOf(tagList)
     }
 
+    // owner のリストを返す関数. 重複を削除して返す. 新しいownerの登録時に、既に登録されているownerのリストを取得するために使用する.
+    suspend fun getOwnerList(db: FirebaseFirestore): ImmutableList<String> {
+        val ownerList = mutableListOf<String>()
+        try {
+            val result = db.collection("C0de").get().await()
+            for (document in result) {
+                val owner = document.data["owner"] as String
+                if (owner != "") {
+                    ownerList.add(owner)
+                }
+            }
+        } catch (e: Exception) {
+            Log.d("error", "getOwnerList: error occurred  ${e.message}  ${e.cause}")
+        }
+        // 重複を削除
+        ownerList.distinct()
+        // ImmutableList に変換して返す
+        return ImmutableList.copyOf(ownerList)
+    }
+
 
     // 以下はGoogle Books API 用の関数
     // Retrofit のインスタンスを作成

--- a/app/src/main/java/com/example/booksharing/room/UserDataDAO.kt
+++ b/app/src/main/java/com/example/booksharing/room/UserDataDAO.kt
@@ -12,10 +12,14 @@ interface UserDataDAO {
     suspend fun insertUserData(userData: UserDataEntity)
 
     // ユーザー名からidを取得する
-    @Query("SELECT id FROM UserDataEntity WHERE UserName = :userName")
+    @Query("SELECT id FROM UserDataEntity WHERE userName = :userName")
     suspend fun getIdByUserName(userName: String): Int
 
     // ユーザー名を変更する
     @Update
     suspend fun updateUserData(userData: UserDataEntity)
+
+    // id = 0 のデータを取得する
+    @Query("SELECT * FROM UserDataEntity WHERE id = 0")
+    suspend fun getUserData(): UserDataEntity
 }

--- a/app/src/main/java/com/example/booksharing/room/UserDataEntity.kt
+++ b/app/src/main/java/com/example/booksharing/room/UserDataEntity.kt
@@ -7,6 +7,6 @@ import androidx.room.PrimaryKey
 data class UserDataEntity(
     // データは1つなので、id は 0 で固定
     @PrimaryKey val id: Int = 0,
-    val UserName: String,
-    val Organization: String = "C0de",
+    val userName: String? = null,
+    val organization: String = "C0de",
 )

--- a/app/src/main/java/com/example/booksharing/screen/HomeScreen.kt
+++ b/app/src/main/java/com/example/booksharing/screen/HomeScreen.kt
@@ -12,16 +12,21 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
 import com.example.booksharing.ViewModel.HomeViewModel
 import com.example.booksharing.firestore.detailforapi
+import com.example.booksharing.room.AppDatabase
 import com.example.booksharing.ui.theme.BookSharingTheme
 import com.example.booksharing.ui_components.BookDisplay
 import com.example.booksharing.ui_components.SearchBox
@@ -30,7 +35,7 @@ import kotlinx.coroutines.launch
 
 
 @Composable
-fun HomeScreen(vm: HomeViewModel = viewModel()) {
+fun HomeScreen(vm: HomeViewModel = viewModel(), navController: NavController) {
     /*
     この画面がアプリのホーム画面になります。
     kindleのように、firebaseから取得した本の情報を表示できるようにしましょう。
@@ -38,6 +43,21 @@ fun HomeScreen(vm: HomeViewModel = viewModel()) {
     val coroutineScope = rememberCoroutineScope()
     // get context
     val context = LocalContext.current
+
+    // Room のインスタンスを作成
+    val db = AppDatabase.getDB(context)
+
+    // room の id = 0 に保存されたデータがあるかどうかを確認し、なければユーザー情報を入力する画面を表示する
+    var isShowInputUserInfoScreen by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) {
+        coroutineScope.launch {
+            val userData = db.userDataDao().getUserData()
+            if (userData == null) {
+                isShowInputUserInfoScreen = true
+            }
+        }
+    }
+
 
     Column(
         modifier = Modifier
@@ -90,12 +110,18 @@ fun HomeScreen(vm: HomeViewModel = viewModel()) {
             }
         }
     }
+
+    if (isShowInputUserInfoScreen) {
+        InputUserInfoScreen(navController = navController)
+    }
 }
 
 @Preview(showBackground = true)
 @Composable
 fun PreviewHomeScreen() {
+    val navController = rememberNavController()
+
     BookSharingTheme {
-        HomeScreen()
+        HomeScreen(navController = navController)
     }
 }

--- a/app/src/main/java/com/example/booksharing/screen/HomeScreen.kt
+++ b/app/src/main/java/com/example/booksharing/screen/HomeScreen.kt
@@ -111,6 +111,7 @@ fun HomeScreen(vm: HomeViewModel = viewModel(), navController: NavController) {
         }
     }
 
+    // 初回起動時にユーザー情報を入力する画面を表示する
     if (isShowInputUserInfoScreen) {
         InputUserInfoScreen(navController = navController)
     }

--- a/app/src/main/java/com/example/booksharing/screen/HomeScreen.kt
+++ b/app/src/main/java/com/example/booksharing/screen/HomeScreen.kt
@@ -25,8 +25,6 @@ import com.example.booksharing.ui.theme.BookSharingTheme
 import com.example.booksharing.ui_components.BookDisplay
 import com.example.booksharing.ui_components.SearchBox
 import com.google.common.collect.ImmutableList
-import com.google.firebase.firestore.ktx.firestore
-import com.google.firebase.ktx.Firebase
 import kotlinx.coroutines.launch
 
 

--- a/app/src/main/java/com/example/booksharing/screen/HomeScreen.kt
+++ b/app/src/main/java/com/example/booksharing/screen/HomeScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -35,6 +36,8 @@ fun HomeScreen(vm: HomeViewModel = viewModel()) {
     kindleのように、firebaseから取得した本の情報を表示できるようにしましょう。
      */
     val coroutineScope = rememberCoroutineScope()
+    // get context
+    val context = LocalContext.current
 
     Column(
         modifier = Modifier

--- a/app/src/main/java/com/example/booksharing/screen/InputUserInfoScreen.kt
+++ b/app/src/main/java/com/example/booksharing/screen/InputUserInfoScreen.kt
@@ -1,0 +1,8 @@
+package com.example.booksharing.screen
+
+import androidx.compose.runtime.Composable
+
+@Composable
+fun InputUserInfoScreen() {
+    // Roomのインスタンスを作成
+}

--- a/app/src/main/java/com/example/booksharing/screen/InputUserInfoScreen.kt
+++ b/app/src/main/java/com/example/booksharing/screen/InputUserInfoScreen.kt
@@ -104,7 +104,10 @@ fun InputUserInfoScreen(vm: HomeViewModel = viewModel(), navController: NavContr
                             try {
                                 db.userDataDao().insertUserData(UserDataEntity(id = 0,userName))
                                 focusManager.clearFocus()
-                                keyboardController?.hide()
+                                withContext(Dispatchers.Main) { // キーボードを閉じるのと画面遷移はメインスレッドで行ったほうがいいのか？
+                                    keyboardController?.hide()
+                                    navController.navigate("home")
+                                }
                             } catch (e: Exception) {
                                 Log.d("methodTest", "insertUserData: error ${e.message}  ${e.cause}")
                             }

--- a/app/src/main/java/com/example/booksharing/screen/InputUserInfoScreen.kt
+++ b/app/src/main/java/com/example/booksharing/screen/InputUserInfoScreen.kt
@@ -1,8 +1,91 @@
 package com.example.booksharing.screen
 
+import android.util.Log
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.tooling.preview.Preview
+import com.example.booksharing.room.AppDatabase
+import com.example.booksharing.room.UserDataEntity
+import com.example.booksharing.ui.theme.BookSharingTheme
+import kotlinx.coroutines.launch
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun InputUserInfoScreen() {
+    // get context
+    val context = LocalContext.current
     // Roomのインスタンスを作成
+    val db = AppDatabase.getDB(context)
+
+    // ユーザー名を保持する変数
+    var userName by remember { mutableStateOf("") }
+
+    val coroutineScope = rememberCoroutineScope()
+
+    // TextFieldの外がタップされたら、フォーカスを外し、キーボードを閉じる
+    val focusManager = LocalFocusManager.current
+    val keyboardController = LocalSoftwareKeyboardController.current
+
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .fillMaxSize()
+            .clickable(
+                interactionSource = MutableInteractionSource(),
+                indication = null
+            ) { focusManager.clearFocus(); keyboardController?.hide() }
+    ) {
+        // ここにユーザー情報を入力する画面を作成します。
+        TextField(
+            value = userName,
+            onValueChange = {
+                userName = it
+            },
+            label = {
+                Text("ユーザー名")
+            },
+            singleLine = true,
+            placeholder = { Text("例: dennoko") }
+        )
+
+        // ユーザー情報の保存ボタン
+        Button(
+            onClick = {
+                coroutineScope.launch {
+                    try {
+                        db.userDataDao().insertUserData(UserDataEntity(id = 0,userName))
+                    } catch (e: Exception) {
+                        Log.d("methodTest", "insertUserData: error ${e.message}  ${e.cause}")
+                    }
+                }
+            }
+        ) {
+            Text(text = "Save")
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewInputUserInfoScreen() {
+    BookSharingTheme {
+        InputUserInfoScreen()
+    }
 }

--- a/app/src/main/java/com/example/booksharing/screen/InputUserInfoScreen.kt
+++ b/app/src/main/java/com/example/booksharing/screen/InputUserInfoScreen.kt
@@ -2,11 +2,13 @@ package com.example.booksharing.screen
 
 import android.util.Log
 import android.widget.Toast
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
@@ -23,6 +25,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
 import com.example.booksharing.ViewModel.HomeViewModel
 import com.example.booksharing.room.AppDatabase
 import com.example.booksharing.room.UserDataEntity
@@ -33,7 +36,7 @@ import kotlinx.coroutines.withContext
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
-fun InputUserInfoScreen(vm: HomeViewModel = viewModel()) {
+fun InputUserInfoScreen(vm: HomeViewModel = viewModel(), navController: NavController) {
     // get context
     val context = LocalContext.current
     // Roomのインスタンスを作成
@@ -68,6 +71,7 @@ fun InputUserInfoScreen(vm: HomeViewModel = viewModel()) {
                 interactionSource = MutableInteractionSource(),
                 indication = null
             ) { focusManager.clearFocus(); keyboardController?.hide() }
+            .background(color = MaterialTheme.colorScheme.surface)
     ) {
         // ここにユーザー情報を入力する画面を作成します。
         TextField(
@@ -99,6 +103,8 @@ fun InputUserInfoScreen(vm: HomeViewModel = viewModel()) {
                         withContext(Dispatchers.IO) {
                             try {
                                 db.userDataDao().insertUserData(UserDataEntity(id = 0,userName))
+                                focusManager.clearFocus()
+                                keyboardController?.hide()
                             } catch (e: Exception) {
                                 Log.d("methodTest", "insertUserData: error ${e.message}  ${e.cause}")
                             }


### PR DESCRIPTION
初回起動時のユーザー情報入力画面を実装しました。
しかし以下の問題点があります
- UIは適当
- ユーザー情報入力前に BottomBar で HomeScreen 以外に遷移することを防げない
- 自分の書籍の情報を追加していないユーザーの名前の重複が防げない

解決策
- UI は頑張る
- BottomBar を押したときに判定を挟む
- 空の書籍情報を保存し、ユーザー名は最初に firebase に保存されるようにする