### PR TITLE
fix: bookSharingルートディレクトリにあった重複しているBooksApiRepositoryを削除しました

### DIFF
--- a/app/src/main/java/com/example/booksharing/BooksApiRepository.kt
+++ b/app/src/main/java/com/example/booksharing/BooksApiRepository.kt
@@ -1,9 +1,0 @@
-package com.example.booksharing.GoogleBooksAPI
-
-class BooksApiRepository {
-    private val apiService = RetrofitInstance.apiService
-
-    suspend fun searchBooks(query: String): BooksData {
-        return apiService.searchBooks(query)
-    }
-}


### PR DESCRIPTION
マージし終わったらこのブランチは消してください